### PR TITLE
test: agregar pruebas unitarias para Q1, Q2 y Q3

### DIFF
--- a/src/challenge.ipynb
+++ b/src/challenge.ipynb
@@ -1311,15 +1311,45 @@
    "metadata": {},
    "source": [
     "--- \n",
-    "## Pruebas unitarias"
+    "### ✅ Pruebas unitarias\n",
+    "\n",
+    "Las funciones `q1_memory`, `q1_time`, `q2_memory`, `q2_time`, `q3_memory` y `q3_time` fueron validadas mediante pruebas unitarias ubicadas en la carpeta `tests/`.\n",
+    "\n",
+    "Las pruebas cubren los siguientes aspectos clave:\n",
+    "\n",
+    "- **Formato de salida:** Verifica que cada función devuelva los datos en el formato esperado (ej. lista de tuplas con tipos correctos).\n",
+    "- **Consistencia entre versiones:** Asegura que las funciones optimizadas para tiempo y memoria generen el mismo resultado para un input controlado.\n",
+    "- **Robustez básica:** Evalúa el comportamiento ante estructuras comunes (ej. emojis, menciones y fechas válidas).\n",
+    "\n",
+    "Estas pruebas pueden ejecutarse directamente desde el notebook.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 62,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1m============================= test session starts =============================\u001b[0m\n",
+      "platform win32 -- Python 3.10.16, pytest-8.3.5, pluggy-1.5.0\n",
+      "rootdir: C:\\Users\\and88\\OneDrive\\Documents\\Python\\latam_challenge_DE\n",
+      "plugins: anyio-4.9.0\n",
+      "collected 6 items\n",
+      "\n",
+      "..\\tests\\test_q1.py \u001b[32m.\u001b[0m\u001b[32m.\u001b[0m\u001b[32m                                                   [ 33%]\u001b[0m\n",
+      "..\\tests\\test_q2.py \u001b[32m.\u001b[0m\u001b[32m.\u001b[0m\u001b[32m                                                   [ 66%]\u001b[0m\n",
+      "..\\tests\\test_q3.py \u001b[32m.\u001b[0m\u001b[32m.\u001b[0m\u001b[32m                                                   [100%]\u001b[0m\n",
+      "\n",
+      "\u001b[32m============================== \u001b[32m\u001b[1m6 passed\u001b[0m\u001b[32m in 0.08s\u001b[0m\u001b[32m ==============================\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pytest ../tests"
+   ]
   }
  ],
  "metadata": {

--- a/src/challenge.ipynb
+++ b/src/challenge.ipynb
@@ -1305,6 +1305,21 @@
     "usuarios_mas_influyentes = q3_time(FILE_PATH)\n",
     "visualizador(usuarios_mas_influyentes, columns=[\"Usuario\", \"Menciones\"])"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "--- \n",
+    "## Pruebas unitarias"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+# tests/conftest.py
+import sys
+import os
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+)

--- a/tests/test_q1.py
+++ b/tests/test_q1.py
@@ -1,0 +1,36 @@
+import datetime
+from q1_memory import q1_memory
+from q1_time import q1_time
+
+
+def test_q1_format(tmp_path):
+    """
+    Verifica que la función q1_memory devuelva una lista de tuplas
+    con formato (datetime.date, str), como se especifica en la consigna.
+    """
+    test_file = tmp_path / "test_q1.json"
+    test_file.write_text(
+        '{"date": "2021-01-01T10:00:00+00:00", "user": {"username": "alice"}}\n'
+        '{"date": "2021-01-01T11:00:00+00:00", "user": {"username": "alice"}}\n'
+        '{"date": "2021-01-02T12:00:00+00:00", "user": {"username": "bob"}}\n',
+        encoding="utf-8",
+    )
+    result = q1_memory(str(test_file))
+    assert isinstance(result, list)
+    assert all(
+        isinstance(x[0], datetime.date) and isinstance(x[1], str) for x in result
+    )
+
+
+def test_q1_same_output(tmp_path):
+    """
+    Verifica que q1_memory y q1_time devuelvan el mismo resultado
+    cuando se les entrega el mismo archivo.
+    """
+    test_file = tmp_path / "test_q1.json"
+    test_file.write_text(
+        '{"date": "2021-01-01T10:00:00+00:00", "user": {"username": "alice"}}\n'
+        '{"date": "2021-01-01T11:00:00+00:00", "user": {"username": "alice"}}\n',
+        encoding="utf-8",
+    )
+    assert q1_memory(str(test_file)) == q1_time(str(test_file))

--- a/tests/test_q2.py
+++ b/tests/test_q2.py
@@ -1,0 +1,26 @@
+from q2_memory import q2_memory
+from q2_time import q2_time
+
+
+def test_q2_format(tmp_path):
+    """
+    Verifica que la salida de q2_memory sea una lista de tuplas
+    (emoji, conteo), donde emoji es str y conteo es int.
+    """
+    test_file = tmp_path / "test_q2.json"
+    test_file.write_text(
+        '{"content": "✈️❤️🔥"}\n' '{"content": "🔥🔥✈️"}\n', encoding="utf-8"
+    )
+    result = q2_memory(str(test_file))
+    assert isinstance(result, list)
+    assert all(isinstance(e, str) and isinstance(c, int) for e, c in result)
+
+
+def test_q2_same_output(tmp_path):
+    """
+    Verifica que q2_memory y q2_time devuelvan el mismo resultado
+    ante un input controlado.
+    """
+    test_file = tmp_path / "test_q2.json"
+    test_file.write_text('{"content": "❤️❤️✈️"}\n', encoding="utf-8")
+    assert q2_memory(str(test_file)) == q2_time(str(test_file))

--- a/tests/test_q3.py
+++ b/tests/test_q3.py
@@ -1,0 +1,30 @@
+from q3_memory import q3_memory
+from q3_time import q3_time
+
+
+def test_q3_format(tmp_path):
+    """
+    Verifica que q3_memory devuelva una lista de tuplas (username, cantidad),
+    con tipos correctos: str e int.
+    """
+    test_file = tmp_path / "test_q3.json"
+    test_file.write_text(
+        '{"mentionedUsers": [{"username": "alice"}]}\n'
+        '{"mentionedUsers": [{"username": "bob"}, {"username": "alice"}]}\n',
+        encoding="utf-8",
+    )
+    result = q3_memory(str(test_file))
+    assert isinstance(result, list)
+    assert all(isinstance(u, str) and isinstance(c, int) for u, c in result)
+
+
+def test_q3_same_output(tmp_path):
+    """
+    Verifica que q3_memory y q3_time devuelvan el mismo resultado
+    con un archivo que contiene menciones simples.
+    """
+    test_file = tmp_path / "test_q3.json"
+    test_file.write_text(
+        '{"mentionedUsers": [{"username": "alice"}]}\n', encoding="utf-8"
+    )
+    assert q3_memory(str(test_file)) == q3_time(str(test_file))


### PR DESCRIPTION
Este PR agrega una suite básica de pruebas unitarias para validar las funciones:

- `q1_memory` y `q1_time`
- `q2_memory` y `q2_time`
- `q3_memory` y `q3_time`

Cada test valida:
- El formato de salida esperado por cada función.
- La consistencia entre versiones optimizadas para tiempo y memoria.

También se incluye en el notebook `challenge.ipynb` una celda para ejecutar `pytest` desde Jupyter, junto con documentación explicativa.
