### PR TITLE
chore: actualización general de salidas en el notebook

### DIFF
--- a/src/challenge.ipynb
+++ b/src/challenge.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 1,
    "metadata": {
     "scrolled": true
    },
@@ -38,9 +38,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The memory_profiler extension is already loaded. To reload it, use:\n",
+      "  %reload_ext memory_profiler\n"
+     ]
+    }
+   ],
    "source": [
     "%load_ext memory_profiler\n",
     "%load_ext line_profiler\n",
@@ -50,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,14 +134,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "peak memory: 111.40 MiB, increment: 6.46 MiB\n"
+      "peak memory: 114.16 MiB, increment: 6.31 MiB\n"
      ]
     }
    ],
@@ -149,7 +158,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 6,
    "metadata": {
     "scrolled": true
    },
@@ -167,14 +176,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3.5 s ± 243 ms per loop (mean ± std. dev. of 3 runs, 10 loops each)\n"
+      "3.45 s ± 119 ms per loop (mean ± std. dev. of 3 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -191,7 +200,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -288,7 +297,7 @@
        "9  2021-02-19         Preetm91"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -322,14 +331,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "peak memory: 522.71 MiB, increment: 412.46 MiB\n"
+      "peak memory: 526.34 MiB, increment: 412.57 MiB\n"
      ]
     }
    ],
@@ -346,14 +355,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3.15 s ± 20.4 ms per loop (mean ± std. dev. of 3 runs, 10 loops each)\n"
+      "3.16 s ± 97.4 ms per loop (mean ± std. dev. of 3 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -370,7 +379,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 11,
    "metadata": {
     "scrolled": true
    },
@@ -529,14 +538,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "peak memory: 483.79 MiB, increment: 0.00 MiB\n"
+      "peak memory: 293.40 MiB, increment: 0.00 MiB\n"
      ]
     }
    ],
@@ -553,7 +562,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 14,
    "metadata": {
     "scrolled": true
    },
@@ -571,14 +580,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "5.61 s ± 61.5 ms per loop (mean ± std. dev. of 3 runs, 10 loops each)\n"
+      "5.64 s ± 95 ms per loop (mean ± std. dev. of 3 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -595,7 +604,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -692,7 +701,7 @@
        "9      👇     1108"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -727,14 +736,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "peak memory: 524.59 MiB, increment: 242.44 MiB\n"
+      "peak memory: 529.20 MiB, increment: 237.19 MiB\n"
      ]
     }
    ],
@@ -751,14 +760,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3.98 s ± 148 ms per loop (mean ± std. dev. of 3 runs, 10 loops each)\n"
+      "4.05 s ± 98.6 ms per loop (mean ± std. dev. of 3 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -775,7 +784,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 19,
    "metadata": {
     "scrolled": true
    },
@@ -795,7 +804,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -892,7 +901,7 @@
        "9      👇     1108"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -935,14 +944,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "peak memory: 460.41 MiB, increment: 0.13 MiB\n"
+      "peak memory: 446.57 MiB, increment: 0.01 MiB\n"
      ]
     }
    ],
@@ -959,7 +968,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 22,
    "metadata": {
     "scrolled": true
    },
@@ -977,14 +986,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3.35 s ± 108 ms per loop (mean ± std. dev. of 3 runs, 10 loops each)\n"
+      "3.3 s ± 37.9 ms per loop (mean ± std. dev. of 3 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -997,204 +1006,6 @@
    "metadata": {},
    "source": [
     "#### Respuesta"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Usuario</th>\n",
-       "      <th>Menciones</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>narendramodi</td>\n",
-       "      <td>2265</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>Kisanektamorcha</td>\n",
-       "      <td>1840</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>RakeshTikaitBKU</td>\n",
-       "      <td>1644</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>PMOIndia</td>\n",
-       "      <td>1427</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>RahulGandhi</td>\n",
-       "      <td>1146</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>GretaThunberg</td>\n",
-       "      <td>1048</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>RaviSinghKA</td>\n",
-       "      <td>1019</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>rihanna</td>\n",
-       "      <td>986</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>UNHumanRights</td>\n",
-       "      <td>962</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>meenaharris</td>\n",
-       "      <td>926</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "           Usuario  Menciones\n",
-       "0     narendramodi       2265\n",
-       "1  Kisanektamorcha       1840\n",
-       "2  RakeshTikaitBKU       1644\n",
-       "3         PMOIndia       1427\n",
-       "4      RahulGandhi       1146\n",
-       "5    GretaThunberg       1048\n",
-       "6      RaviSinghKA       1019\n",
-       "7          rihanna        986\n",
-       "8    UNHumanRights        962\n",
-       "9      meenaharris        926"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "usuarios_mas_influyentes = q3_memory(FILE_PATH)\n",
-    "visualizador(usuarios_mas_influyentes, columns=[\"Usuario\", \"Menciones\"])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Enfoque de tiempo optimizado\n",
-    "\n",
-    "Para minimizar el tiempo de ejecución, esta versión de la función implementa las siguientes estrategias:\n",
-    "\n",
-    "- Procesa el archivo línea por línea (modo streaming).\n",
-    "- Utiliza una expresión regular para **filtrar** solo las líneas que contienen al menos una mención válida en el campo `mentionedUsers`, reduciendo significativamente el número de parseos JSON necesarios.\n",
-    "- Solo parsea los tweets que cumplen con ese patrón, lo que mejora el rendimiento en archivos con muchos tweets sin menciones.\n",
-    "- Utiliza la estructura `Counter` para contar eficientemente la cantidad de veces que cada usuario es mencionado.\n",
-    "- Ignora los tweets mal formateados o sin usuarios mencionados, evitando validaciones adicionales o estructuras innecesarias.\n",
-    "- Devuelve los 10 usuarios más mencionados ordenados por frecuencia, utilizando el método `most_common()` de `Counter`.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Prueba de memoria"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "peak memory: 427.77 MiB, increment: 0.00 MiB\n"
-     ]
-    }
-   ],
-   "source": [
-    "%memit q3_time(FILE_PATH)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Prueba de tiempo"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2.25 s ± 243 ms per loop (mean ± std. dev. of 3 runs, 10 loops each)\n"
-     ]
-    }
-   ],
-   "source": [
-    "%timeit -n 10 -r 3 q3_time(FILE_PATH)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Análisis de tiempo"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 61,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "# %lprun -f q3_time q3_time(FILE_PATH) # resultado en la carpeta outs "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Resultado"
    ]
   },
   {
@@ -1302,6 +1113,204 @@
     }
    ],
    "source": [
+    "usuarios_mas_influyentes = q3_memory(FILE_PATH)\n",
+    "visualizador(usuarios_mas_influyentes, columns=[\"Usuario\", \"Menciones\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Enfoque de tiempo optimizado\n",
+    "\n",
+    "Para minimizar el tiempo de ejecución, esta versión de la función implementa las siguientes estrategias:\n",
+    "\n",
+    "- Procesa el archivo línea por línea (modo streaming).\n",
+    "- Utiliza una expresión regular para **filtrar** solo las líneas que contienen al menos una mención válida en el campo `mentionedUsers`, reduciendo significativamente el número de parseos JSON necesarios.\n",
+    "- Solo parsea los tweets que cumplen con ese patrón, lo que mejora el rendimiento en archivos con muchos tweets sin menciones.\n",
+    "- Utiliza la estructura `Counter` para contar eficientemente la cantidad de veces que cada usuario es mencionado.\n",
+    "- Ignora los tweets mal formateados o sin usuarios mencionados, evitando validaciones adicionales o estructuras innecesarias.\n",
+    "- Devuelve los 10 usuarios más mencionados ordenados por frecuencia, utilizando el método `most_common()` de `Counter`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Prueba de memoria"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "peak memory: 446.59 MiB, increment: 0.00 MiB\n"
+     ]
+    }
+   ],
+   "source": [
+    "%memit q3_time(FILE_PATH)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Prueba de tiempo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2.13 s ± 27.2 ms per loop (mean ± std. dev. of 3 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%timeit -n 10 -r 3 q3_time(FILE_PATH)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Análisis de tiempo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# %lprun -f q3_time q3_time(FILE_PATH) # resultado en la carpeta outs "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Resultado"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Usuario</th>\n",
+       "      <th>Menciones</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>narendramodi</td>\n",
+       "      <td>2265</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Kisanektamorcha</td>\n",
+       "      <td>1840</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>RakeshTikaitBKU</td>\n",
+       "      <td>1644</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>PMOIndia</td>\n",
+       "      <td>1427</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>RahulGandhi</td>\n",
+       "      <td>1146</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>GretaThunberg</td>\n",
+       "      <td>1048</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>RaviSinghKA</td>\n",
+       "      <td>1019</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>rihanna</td>\n",
+       "      <td>986</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>UNHumanRights</td>\n",
+       "      <td>962</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>meenaharris</td>\n",
+       "      <td>926</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           Usuario  Menciones\n",
+       "0     narendramodi       2265\n",
+       "1  Kisanektamorcha       1840\n",
+       "2  RakeshTikaitBKU       1644\n",
+       "3         PMOIndia       1427\n",
+       "4      RahulGandhi       1146\n",
+       "5    GretaThunberg       1048\n",
+       "6      RaviSinghKA       1019\n",
+       "7          rihanna        986\n",
+       "8    UNHumanRights        962\n",
+       "9      meenaharris        926"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
     "usuarios_mas_influyentes = q3_time(FILE_PATH)\n",
     "visualizador(usuarios_mas_influyentes, columns=[\"Usuario\", \"Menciones\"])"
    ]
@@ -1326,7 +1335,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
Este PR actualiza las salidas del archivo `challenge.ipynb` tras ejecutar nuevamente el notebook con un entorno limpio (sin __pycache__).

Cambios realizados:
- Salidas regeneradas de las funciones de `q1`, `q2`, `q3`
- Notebook con medidas de memoria y tiempo (sin caché previo)
- Sin cambios en lógica ni funciones
